### PR TITLE
delete seed nodes before deployment

### DIFF
--- a/9c-main/deploy-main.sh
+++ b/9c-main/deploy-main.sh
@@ -19,6 +19,11 @@ delete_miner() {
 }
 
 clear_cluster() {
+  kubectl delete deployment \
+    main-tcp-seed-1 \
+    main-tcp-seed-2 \
+    main-tcp-seed-3
+
   kubectl delete sts \
     main-full-state \
     main-miner-2 \


### PR DESCRIPTION
This prevents seed nodes from not updating when there are no changes in the yaml files.