### PR TITLE
[Data Provider] don't check tip when resetting snapshot

### DIFF
--- a/9c-internal/configmap-data-provider.yaml
+++ b/9c-internal/configmap-data-provider.yaml
@@ -17,23 +17,28 @@ data:
     DP_TOKEN=$3
     DP_PORT=$4
     DP_DATABASE=$5
-    FILE="/data/blockIndex.txt"
-    CHAIN_TIP_INDEX="$(($HOME/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable chain tip "RocksDb" "/data/data-provider") | jq -r '.Index')"
+    RESET_SNAPSHOT_OPTION=$6
 
-    RENDERED_BLOCK_INDEX=$CHAIN_TIP_INDEX
-    if [ -f "$FILE" ]; then
-        RENDERED_BLOCK_INDEX="$(cat "/data/blockIndex.txt")"
-    else
-        echo $FILE does not exist. Get the latest block index from the database.
-        MYSQL_BLOCK_INDEX=$(mysql --host=$DP_HOST --user=$DP_USER --password=$DP_TOKEN --port=$DP_PORT --database=$DP_DATABASE --skip-column-names -e "SELECT \`Index\` FROM $DP_DATABASE.Blocks order by \`Index\` desc limit 1;")
-        RENDERED_BLOCK_INDEX=$MYSQL_BLOCK_INDEX
-    fi
-
-    TIP_DIFF=$(( $CHAIN_TIP_INDEX - $RENDERED_BLOCK_INDEX ))
-    if (( $TIP_DIFF > 0 ))
+    if [ $download_option = n ]
     then
-      echo Truncate chain tip by $TIP_DIFF.
-      $HOME/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable chain truncate "RocksDb" "/data/data-provider" $TIP_DIFF
-    else
-      echo No need to truncate chain tip.
+      FILE="/data/blockIndex.txt"
+      CHAIN_TIP_INDEX="$(($HOME/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable chain tip "RocksDb" "/data/data-provider") | jq -r '.Index')"
+
+      RENDERED_BLOCK_INDEX=$CHAIN_TIP_INDEX
+      if [ -f "$FILE" ]; then
+          RENDERED_BLOCK_INDEX="$(cat "/data/blockIndex.txt")"
+      else
+          echo $FILE does not exist. Get the latest block index from the database.
+          MYSQL_BLOCK_INDEX=$(mysql --host=$DP_HOST --user=$DP_USER --password=$DP_TOKEN --port=$DP_PORT --database=$DP_DATABASE --skip-column-names -e "SELECT \`Index\` FROM $DP_DATABASE.Blocks order by \`Index\` desc limit 1;")
+          RENDERED_BLOCK_INDEX=$MYSQL_BLOCK_INDEX
+      fi
+
+      TIP_DIFF=$(( $CHAIN_TIP_INDEX - $RENDERED_BLOCK_INDEX ))
+      if (( $TIP_DIFF > 0 ))
+      then
+        echo Truncate chain tip by $TIP_DIFF.
+        $HOME/NineChronicles.Headless.Executable/NineChronicles.Headless.Executable chain truncate "RocksDb" "/data/data-provider" $TIP_DIFF
+      else
+        echo No need to truncate chain tip.
+      fi
     fi

--- a/9c-internal/data-provider.yaml
+++ b/9c-internal/data-provider.yaml
@@ -56,7 +56,7 @@ spec:
         name: wait-for-miner
       containers:
       - args:
-        - /bin/check_chain_tip.sh $(DP_HOST) $(DP_USER) $(DP_TOKEN) $(DP_PORT) $(DP_DATABASE) && /app/NineChronicles.DataProvider.Executable
+        - /bin/check_chain_tip.sh $(DP_HOST) $(DP_USER) $(DP_TOKEN) $(DP_PORT) $(DP_DATABASE) $(RESET_SNAPSHOT_OPTION) && /app/NineChronicles.DataProvider.Executable
         command:
         - /bin/sh
         - -c
@@ -68,6 +68,11 @@ spec:
             configMapKeyRef:
               name: version-config
               key: APP_PROTOCOL_VERSION
+        - name: RESET_SNAPSHOT_OPTION
+          valueFrom:
+            configMapKeyRef:
+              name: reset-snapshot-option
+              key: RESET_SNAPSHOT_OPTION
         - name: NC_Confirmations
           value: '0'
         - name: NC_PeerStrings__0


### PR DESCRIPTION
This PR configures internal dp to ignore `check_tip.sh` script when setting up cluster for the first time.