### PR TITLE
Disable grafana chart `initChownData` feature

### DIFF
--- a/9c-main/monitoring/grafana-values.yaml
+++ b/9c-main/monitoring/grafana-values.yaml
@@ -12,5 +12,8 @@ persistence:
   enabled: true
   storageClassName: gp2-extensible-us-east-2b
 
+initChownData:
+  enabled: false
+
 service:
   type: LoadBalancer


### PR DESCRIPTION
While updating the Grafana Helm chart to the latest version, it stops running a new pod because of the `initChownData` init container job.

This pull request disables it.

### References

- https://github.com/grafana/helm-charts/blob/6e2ff8a3ac164e8f5029d021d7c8504307f76f26/charts/grafana/README.md#configuration
- https://github.com/grafana/helm-charts/issues/615