### PR TITLE
reduce internal cluster setup time

### DIFF
--- a/9c-internal/configmap-snapshot-script.yaml
+++ b/9c-internal/configmap-snapshot-script.yaml
@@ -35,8 +35,58 @@ data:
           echo "$snapshot_param_return_value"
       }
 
-      function download_unzip_snapshot() {
+      function download_unzip_partial_snapshot() {
+        snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
+        snapshot_zip_filename="state_latest.zip"
+        snapshot_zip_filename_array=("$snapshot_zip_filename")
+
+        while :
+        do
+            snapshot_json_url="$base_url/$snapshot_json_filename"
+
+            BlockEpoch=$(get_snapshot_value "$snapshot_json_url" "BlockEpoch")
+            TxEpoch=$(get_snapshot_value "$snapshot_json_url" "TxEpoch")
+            PreviousBlockEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousBlockEpoch")
+            PreviousTxEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousTxEpoch")
+
+            snapshot_zip_filename="snapshot-$BlockEpoch-$TxEpoch.zip"
+            snapshot_zip_filename_array+=("$snapshot_zip_filename")
+
+            if [ "$PreviousBlockEpoch" -lt $1 ]
+            then
+                break
+            fi
+
+            snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
+        done
+
+        if [[ ! -d "$save_dir" ]]
+        then
+            echo "[Info] The directory $save_dir does not exist and is created."
+            mkdir -p "$save_dir"
+        fi
+
+        for ((i=${#snapshot_zip_filename_array[@]}-1; i>=0; i--))
+        do
+            snapshot_zip_filename="${snapshot_zip_filename_array[$i]}"
+            rm "$snapshot_zip_filename" 2>/dev/null
+
+            snapshot_zip_url="$base_url/$snapshot_zip_filename"
+            echo "$snapshot_zip_url"
+
+            wget -q "$snapshot_zip_url"
+            echo "Unzipping $snapshot_zip_filename"
+            unzip -o "$snapshot_zip_filename" -d "$save_dir"
+            rm "$snapshot_zip_filename"
+        done
+
+        wget -q "$base_url/$mainnet_snapshot_json_filename" -O "$save_dir/$mainnet_snapshot_json_filename"
+      }
+
+      function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -61,8 +111,11 @@ data:
               snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
           done
 
-          echo "MKDIR $save_dir"
-          mkdir -p "$save_dir"
+          if [[ ! -d "$save_dir" ]]
+          then
+              echo "[Info] The directory $save_dir does not exist and is created."
+              mkdir -p "$save_dir"
+          fi
 
           for ((i=${#snapshot_zip_filename_array[@]}-1; i>=0; i--))
           do
@@ -77,17 +130,17 @@ data:
               unzip -o "$snapshot_zip_filename" -d "$save_dir"
               rm "$snapshot_zip_filename"
           done
+
+          wget -q "$base_url/$mainnet_snapshot_json_filename" -O "$save_dir/$mainnet_snapshot_json_filename"
       }
 
-      DIRECTORY="$save_dir"
-      echo "$DIRECTORY"
-      if [[ -d "$DIRECTORY" ]]
+      if [ -f $save_dir/mainnet_latest.json ]
       then
-          echo "[Info] The directory $save_dir exists and is deleted."
-          sudo rm -rf "$save_dir"
+        local_previous_mainnet_blockEpoch=$(cat "$save_dir/mainnet_latest.json" | jq ".BlockEpoch")
+        download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch
+      else
+        download_unzip_full_snapshot
       fi
-
-      download_unzip_snapshot
 
       # The return value for the program that calls this script
       echo "$save_dir"

--- a/9c-internal/deploy-internal.sh
+++ b/9c-internal/deploy-internal.sh
@@ -22,31 +22,88 @@ clean_db() {
 
 # AWS configuration must be already set on your environment
 reset_snapshot() {
-  curl --data "[K8S] Copying 9c-main snapshots to 9c-internal." 'https://planetariumhq.slack.com/services/hooks/slackbot?token=$3&channel=%239c-internal'
-  ARCHIVE="archive_"$(date '+%Y%m%d%H')
-  INTERNAL_PREFIX=$(echo $1 | awk '{gsub(/\//,"\\/");print}')
-  ARCHIVE_PATH=$1$ARCHIVE/
-  ARCHIVE_PREFIX=$(echo $ARCHIVE_PATH | awk '{gsub(/\//,"\\/");print}')
-  MAIN_PREFIX=$(echo $2 | awk '{gsub(/\//,"\\/");print}')
+  if [[ Previous_Mainnet_BlockEpoch=$(curl --silent "snapshots.nine-chronicles.com/internal/mainnet_latest.json" | jq ".BlockEpoch") -gt 0 ]]; then
+    base_url="snapshots.nine-chronicles.com/main/partition/internal"
 
-  # archive internal cluster chain
-  for f in $(aws s3 ls $1 | awk 'NF>1{print $4}' | grep "zip\|json"); do
-    echo $f
-    aws s3 mv $(echo $f | sed "s/.*/$INTERNAL_PREFIX&/") $(echo $f | sed "s/.*/$ARCHIVE_PREFIX&/")
-  done
+    get_snapshot_value() {
+        snapshot_json_url="$1"
+        snapshot_param="$2"
 
-  # copy main cluster chain to internal (copy state_latest.zip first)
-  aws s3 cp "$2state_latest.zip" "$1state_latest.zip"
-  for f in $(aws s3 ls $2 | sort -k1,2 | sort -r | awk 'NF>1{print $4}' | grep "zip\|json" | grep -v "state_latest.zip"); do
-    echo $f
-    aws s3 cp $(echo $f | sed "s/.*/$MAIN_PREFIX&/") $(echo $f | sed "s/.*/$INTERNAL_PREFIX&/")
-  done
+        snapshot_param_return_value=$(curl --silent "$snapshot_json_url" | jq ".$snapshot_param")
+        echo "$snapshot_param_return_value"
+    }
 
-  aws s3 cp "$1latest.json" "$1mainnet_latest.json"
+    copy_snapshot() {
+        snapshot_json_filename="latest.json"
+        snapshot_zip_filename="state_latest.zip"
+        snapshot_zip_filename_array=("$snapshot_zip_filename")
+        snapshot_zip_filename_array+=("latest.zip")
+        snapshot_zip_filename_array+=("latest.json")
+        aws s3 cp "$2/state_latest.zip" "$1/state_latest.zip"
+        aws s3 cp "$2/latest.zip" "$1/latest.zip"
+        aws s3 cp "$2/latest.json" "$1/latest.json"
+        aws s3 cp "$2/latest.json" "$1/mainnet_latest.json"
+
+        while :
+        do
+            snapshot_json_url="$base_url/$snapshot_json_filename"
+
+            BlockEpoch=$(get_snapshot_value "$snapshot_json_url" "BlockEpoch")
+            TxEpoch=$(get_snapshot_value "$snapshot_json_url" "TxEpoch")
+            PreviousBlockEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousBlockEpoch")
+            PreviousTxEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousTxEpoch")
+
+            snapshot_zip_filename="snapshot-$BlockEpoch-$TxEpoch.zip"
+            snapshot_json_filename="snapshot-$BlockEpoch-$TxEpoch.json"
+            aws s3 cp "$2/$snapshot_zip_filename" "$1/$snapshot_zip_filename"
+            aws s3 cp "$2/$snapshot_json_filename" "$1/$snapshot_json_filename"
+            snapshot_zip_filename_array+=("$snapshot_zip_filename")
+            snapshot_zip_filename_array+=("$snapshot_json_filename")
+
+            if [ "$PreviousBlockEpoch" -lt $Previous_Mainnet_BlockEpoch ]
+            then
+                break
+            fi
+
+            snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
+        done
+
+        for ((i=${#snapshot_zip_filename_array[@]}-1; i>=0; i--))
+        do
+            snapshot_zip_filename="${snapshot_zip_filename_array[$i]}"
+        done
+    }
+
+    curl --data "[K8S] Copying 9c-main snapshots to 9c-internal." 'https://planetariumhq.slack.com/services/hooks/slackbot?token=$3&channel=%239c-internal'
+    copy_snapshot $1 $2
+  else
+    curl --data "[K8S] Copying 9c-main snapshots to 9c-internal." 'https://planetariumhq.slack.com/services/hooks/slackbot?token=$3&channel=%239c-internal'
+    ARCHIVE="archive_"$(date '+%Y%m%d%H')
+    INTERNAL_PREFIX=$(echo $1/ | awk '{gsub(/\//,"\\/");print}')
+    ARCHIVE_PATH=$1/$ARCHIVE/
+    ARCHIVE_PREFIX=$(echo $ARCHIVE_PATH | awk '{gsub(/\//,"\\/");print}')
+    MAIN_PREFIX=$(echo $2/ | awk '{gsub(/\//,"\\/");print}')
+
+    # archive internal cluster chain
+    for f in $(aws s3 ls $1/ | awk 'NF>1{print $4}' | grep "zip\|json"); do
+      echo $f
+      aws s3 mv $(echo $f | sed "s/.*/$INTERNAL_PREFIX&/") $(echo $f | sed "s/.*/$ARCHIVE_PREFIX&/")
+    done
+
+    # copy main cluster chain to internal (copy state_latest.zip first)
+    aws s3 cp "$2/state_latest.zip" "$1/state_latest.zip"
+    for f in $(aws s3 ls $2/ | sort -k1,2 | sort -r | awk 'NF>1{print $4}' | grep "zip\|json" | grep -v "state_latest.zip"); do
+      echo $f
+      aws s3 cp $(echo $f | sed "s/.*/$MAIN_PREFIX&/") $(echo $f | sed "s/.*/$INTERNAL_PREFIX&/")
+    done
+
+    aws s3 cp "$1/latest.json" "$1/mainnet_latest.json"
+
+  fi
 
   BUCKET="s3://9c-snapshots"
   BUCKET_PREFIX=$(echo $BUCKET | awk '{gsub(/\//,"\\/");print}')
-  CF_PATH=$(echo $1 | sed -e "s/^$BUCKET_PREFIX//" | sed "s/.*/&*/")
+  CF_PATH=$(echo $1/ | sed -e "s/^$BUCKET_PREFIX//" | sed "s/.*/&*/")
 
   # reset cf path
   CF_DISTRIBUTION_ID="EAU4XRUZSBUD5"
@@ -77,7 +134,7 @@ if [ $response = y ]
 then
     echo "Reset cluster with a new snapshot"
     curl --data "[K8S] Reset cluster with a new snapshot" "https://planetariumhq.slack.com/services/hooks/slackbot?token=$slack_token&channel=%239c-internal"
-    reset_snapshot "s3://9c-snapshots/internal/" "s3://9c-snapshots/main/partition/" $slack_token || true
+    reset_snapshot "s3://9c-snapshots/internal" "s3://9c-snapshots/main/partition/internal" $slack_token || true
 else
     echo "Reset cluster without resetting snapshot."
     curl --data "[K8S] Reset cluster without resetting snapshot." "https://planetariumhq.slack.com/services/hooks/slackbot?token=$slack_token&channel=%239c-internal"

--- a/9c-main/configmap-partition.yaml
+++ b/9c-main/configmap-partition.yaml
@@ -182,6 +182,8 @@ data:
       S3_BUCKET_NAME="9c-snapshots"
       S3_LATEST_SNAPSHOT_PATH="main/partition/$UPLOAD_SNAPSHOT_FILENAME"
       S3_LATEST_METADATA_PATH="main/partition/$UPLOAD_METADATA_FILENAME"
+      S3_LATEST_INTERNAL_SNAPSHOT_PATH="main/partition/internal/$UPLOAD_SNAPSHOT_FILENAME"
+      S3_LATEST_INTERNAL_METADATA_PATH="main/partition/internal/$UPLOAD_METADATA_FILENAME"
 
       AWS="/usr/local/bin/aws"
       AWS_ACCESS_KEY_ID="$(cat "/secret/aws_access_key_id" | base64)"
@@ -202,9 +204,20 @@ data:
 
       "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_SNAPSHOT_FILENAME" "s3://$S3_BUCKET_NAME/$S3_LATEST_SNAPSHOT_PATH" --quiet --acl public-read
       "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_METADATA_FILENAME" "s3://$S3_BUCKET_NAME/$S3_LATEST_METADATA_PATH" --quiet --acl public-read
+
       invalidate_cf "/main/partition/$SNAPSHOT_FILENAME.*"
       invalidate_cf "/main/partition/$UPLOAD_FILENAME.*"
       invalidate_cf "/main/partition/$STATE_FILENAME.*"
+
+      "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_SNAPSHOT_FILENAME" "s3://$S3_BUCKET_NAME/main/partition/internal/$LATEST_SNAPSHOT_FILENAME" --quiet --acl public-read
+      "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_METADATA_FILENAME" "s3://$S3_BUCKET_NAME/main/partition/internal/$LATEST_METADATA_FILENAME" --quiet --acl public-read
+      "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_STATE_FILENAME" "s3://$S3_BUCKET_NAME/main/partition/internal/$LATEST_STATE_FILENAME" --quiet --acl public-read
+      "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/internal/$LATEST_SNAPSHOT_FILENAME" "s3://$S3_BUCKET_NAME/$S3_LATEST_INTERNAL_SNAPSHOT_PATH" --quiet --acl public-read
+      "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/internal/$LATEST_METADATA_FILENAME" "s3://$S3_BUCKET_NAME/$S3_LATEST_INTERNAL_METADATA_PATH" --quiet --acl public-read
+
+      invalidate_cf "/main/partition/internal/$SNAPSHOT_FILENAME.*"
+      invalidate_cf "/main/partition/internal/$UPLOAD_FILENAME.*"
+      invalidate_cf "/main/partition/internal/$STATE_FILENAME.*"
 
       rm "$LATEST_SNAPSHOT"
       rm "$LATEST_STATE"


### PR DESCRIPTION
This PR reduces:
- time it takes to copy the mainnet snapshot to the internal cluster.
- time it takes for internal cluster pods to download the internal snapshot.

This is done by copying/downloading only the required files compared to the previous method which dealt with all snapshot files for each cluster reset.

From a metric standpoint, approximately 1hr+ of internal cluster prep work has been reduced to about 10 mins.