### PR TITLE
feat: Upgrade 9c-headless-metrics-aggregator

### DIFF
--- a/9c-main/monitoring/9c-headless-metrics-aggregator.yaml
+++ b/9c-main/monitoring/9c-headless-metrics-aggregator.yaml
@@ -22,7 +22,7 @@ spec:
         app: ninechronicles-headless-metrics-aggregator
     spec:
       containers:
-      - image: planetariumhq/ninechronicles-headless-metrics-aggregator:git-ba689df528345d1cbefb968cd1a4a434582c6900
+      - image: planetariumhq/ninechronicles-headless-metrics-aggregator:git-a09b032859ebee5e1bcbf132f731e794135a4717
         imagePullPolicy: IfNotPresent
         command:
           - poetry


### PR DESCRIPTION
Please see https://github.com/planetarium/9c-headless-metric-gql-aggregator/commit/28ff3a09d4cd3b7618e5c75ba03be18cbc15c527 commit.

 - Introduce a new metric, `ninechronicles_subscriber_addresses_count`

----

This change is already applied.