### PR TITLE
feat: Upgrade 9c-headless-metrics-aggregator

### DIFF
--- a/9c-main/monitoring/9c-headless-metrics-aggregator.yaml
+++ b/9c-main/monitoring/9c-headless-metrics-aggregator.yaml
@@ -22,7 +22,7 @@ spec:
         app: ninechronicles-headless-metrics-aggregator
     spec:
       containers:
-      - image: planetariumhq/ninechronicles-headless-metrics-aggregator:git-13ee4944967526a98d5256fa669cf41d00f7d453
+      - image: planetariumhq/ninechronicles-headless-metrics-aggregator:git-590e58630c8df25673ed7522c3f82df49f38b133
         imagePullPolicy: IfNotPresent
         command:
           - poetry

--- a/9c-main/monitoring/9c-headless-metrics-aggregator.yaml
+++ b/9c-main/monitoring/9c-headless-metrics-aggregator.yaml
@@ -22,7 +22,7 @@ spec:
         app: ninechronicles-headless-metrics-aggregator
     spec:
       containers:
-      - image: planetariumhq/ninechronicles-headless-metrics-aggregator:git-a09b032859ebee5e1bcbf132f731e794135a4717
+      - image: planetariumhq/ninechronicles-headless-metrics-aggregator:git-13ee4944967526a98d5256fa669cf41d00f7d453
         imagePullPolicy: IfNotPresent
         command:
           - poetry

--- a/9c-main/monitoring/README.md
+++ b/9c-main/monitoring/README.md
@@ -74,3 +74,14 @@ kubectl apply -f 9c-headless-metrics-aggregator.yaml
 [Prometheus]: https://prometheus.io/
 [Grafana]: https://grafana.com/
 [9c-headless-metrics-aggregator]: https://github.com/planetarium/9c-headless-metrics-aggregator
+
+
+## Tips
+
+### Prometheus
+
+Prometheus has its dashboard and you can access it with `kubectl port-forward` command. The full command is the below code:
+
+```
+kubectl port-forward svc/prometheus-server 9090:80
+```


### PR DESCRIPTION
This pull request upgrades 9c-headless-metrics-aggregator. About these changes, please see https://github.com/planetarium/9c-headless-metric-gql-aggregator/compare/a09b032859ebee5e1bcbf132f731e794135a4717..590e58630c8df25673ed7522c3f82df49f38b133.