### PR TITLE
Fix reset snapshot CI

### DIFF
--- a/.github/workflows/snapshot-reset.yaml
+++ b/.github/workflows/snapshot-reset.yaml
@@ -23,5 +23,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_ORG_TOKEN: ${{ secrets.SLACK_ORG_TOKEN }}


### PR DESCRIPTION
This PR fixes the reset snapshot CI which previously couldn't cp s3 objects.