### PR TITLE
update genesis block path in DP configuration

### DIFF
--- a/9c-main/data-provider-db.yaml
+++ b/9c-main/data-provider-db.yaml
@@ -51,6 +51,8 @@ spec:
           value: 'true'
         - name: NC_BlockInsertInterval
           value: '5'
+        - name: NC_GenesisBlockPath
+          value: "https://release.nine-chronicles.com/genesis-block-9c-main"
         - name: NC_MySqlConnectionString
           valueFrom:
             secretKeyRef:

--- a/9c-main/data-provider.yaml
+++ b/9c-main/data-provider.yaml
@@ -45,6 +45,8 @@ spec:
           value: 'true'
         - name: NC_Render
           value: 'false'
+        - name: NC_GenesisBlockPath
+          value: "https://release.nine-chronicles.com/genesis-block-9c-main"
         - name: NC_MySqlConnectionString
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Manually setting the genesis block path for v100350 because https://github.com/planetarium/NineChronicles.DataProvider/pull/320 isn't included.