### PR TITLE
update nodegroups

### DIFF
--- a/9c-main/data-provider-db.yaml
+++ b/9c-main/data-provider-db.yaml
@@ -121,7 +121,7 @@ spec:
           name: main-data-provider-db-data
       dnsPolicy: ClusterFirst
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-c5-4xl
+        alpha.eksctl.io/nodegroup-name: 9c-main-m6g-2xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/data-provider-db.yaml
+++ b/9c-main/data-provider-db.yaml
@@ -50,7 +50,7 @@ spec:
         - name: NC_Render
           value: 'true'
         - name: NC_BlockInsertInterval
-          value: '5'
+          value: '10'
         - name: NC_TrustedAppProtocolVersionSigners__0
           value: 030ffa9bd579ee1503ce008394f687c182279da913bfaec12baca34e79698a7cd1
         - name: NC_GenesisBlockPath

--- a/9c-main/data-provider.yaml
+++ b/9c-main/data-provider.yaml
@@ -98,7 +98,7 @@ spec:
           name: main-data-provider-data
       dnsPolicy: ClusterFirst
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-c5-4xl
+        alpha.eksctl.io/nodegroup-name: 9c-main-m6g-2xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/explorer.yaml
+++ b/9c-main/explorer.yaml
@@ -127,7 +127,7 @@ items:
             subPath: readiness_probe.sh
         dnsPolicy: ClusterFirst
         nodeSelector:
-          alpha.eksctl.io/nodegroup-name: 9c-main-2xl
+          alpha.eksctl.io/nodegroup-name: 9c-main
           beta.kubernetes.io/os: linux
         restartPolicy: Always
         schedulerName: default-scheduler

--- a/9c-main/full-state.yaml
+++ b/9c-main/full-state.yaml
@@ -98,7 +98,7 @@ spec:
           subPath: liveness_probe.sh
       dnsPolicy: ClusterFirst
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-c5-4xl
+        alpha.eksctl.io/nodegroup-name: 9c-main-m6g-2xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/miner-3.yaml
+++ b/9c-main/miner-3.yaml
@@ -86,7 +86,7 @@ spec:
         resources:
           requests:
             cpu: 1300m
-            memory: 20Gi
+            memory: 5Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -100,7 +100,7 @@ spec:
       imagePullSecrets:
       - name: acr-regcred
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-c5-4xl
+        alpha.eksctl.io/nodegroup-name: 9c-main
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/tcp-seed-deployment-1.yaml
+++ b/9c-main/tcp-seed-deployment-1.yaml
@@ -67,7 +67,7 @@ spec:
       imagePullSecrets:
       - name: acr-regcred
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-2xl
+        alpha.eksctl.io/nodegroup-name: 9c-main-xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/tcp-seed-deployment-2.yaml
+++ b/9c-main/tcp-seed-deployment-2.yaml
@@ -67,7 +67,7 @@ spec:
       imagePullSecrets:
       - name: acr-regcred
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-2xl
+        alpha.eksctl.io/nodegroup-name: 9c-main-xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/tcp-seed-deployment-3.yaml
+++ b/9c-main/tcp-seed-deployment-3.yaml
@@ -67,7 +67,7 @@ spec:
       imagePullSecrets:
       - name: acr-regcred
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-main-2xl
+        alpha.eksctl.io/nodegroup-name: 9c-main-xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-onboarding/sts-headless-query.yaml
+++ b/9c-onboarding/sts-headless-query.yaml
@@ -102,7 +102,7 @@ spec:
           subPath: probe_tip.sh
       dnsPolicy: ClusterFirst
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-onboarding-c5-4xl
+        alpha.eksctl.io/nodegroup-name: 9c-onboarding-m6g-2xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
I've scaled down instance types for the following services:
- main-data-provider
- main-data-provider-db
- main-full-state
- explorer
- main-miner-3 (dummy miner)
- seed
- onboarding headless

Nodegroup capacities are also scaled down accordingly.