### PR TITLE
[Fix] Rollback wait pod script

### DIFF
--- a/9c-main/deploy-main.sh
+++ b/9c-main/deploy-main.sh
@@ -39,11 +39,8 @@ clear_cluster() {
     remote-headless-99
 
     # Provide ample time so that the nodes can be fully terminated before a new deployment
-    while [[ $(kubectl get pod -o name) ]]
-    do
-      echo "Provide ample time so that the nodes can be fully terminated before a new deployment"
-      sleep 5s
-    done
+    echo "Provide ample time so that the nodes can be fully terminated before a new deployment"
+    sleep 60
 }
 
 deploy_cluster() {


### PR DESCRIPTION
https://github.com/planetarium/9c-k8s-config/pull/153/files#r1054058314

The `while [[ $(kubectl get pod -o name) ]]` is also wait until the cron job's pods are removed, however we don't want it
Additionally, this deploy-main script will eventually be replaced by Argo CD, so we want to avoid making any fixes to it.