### PR TITLE
Update miner livenessprobe

### DIFF
--- a/9c-main/configmap-probe.yaml
+++ b/9c-main/configmap-probe.yaml
@@ -37,6 +37,29 @@ data:
       echo [[ $(( miner_tip - local_tip)) -lt 10 ]]
       [[ $(( miner_tip - local_tip)) -lt 10 ]]
     fi
+  liveness_probe_miner.sh: |-
+    #!/usr/bin/env bash
+    set -ex
+
+    stagedTxIdsCount="$(
+      curl \
+      -H 'Content-Type: application/json' \
+      --data '{"query":"query{nodeStatus{stagedTxIds}}"}' \
+      http://localhost:80/graphql | jq .data.nodeStatus | jq '.stagedTxIds | length'
+    )"
+
+    if [[ $(( stagedTxIdsCount )) -gt 0 ]]; then
+      last_block="$(
+        curl \
+        -H 'Content-Type: application/json' \
+        --data '{"query":"query{chainQuery{blockQuery{blocks(desc:true,limit:1){timestamp}}}}"}' \
+        http://localhost:80/graphql | jq -r '.data.chainQuery.blockQuery.blocks[0].timestamp')"
+      last_timestamp="$(date +%s -u --date="$last_block")"
+      now="$(date +%s)"
+      [[ $(( now - last_timestamp )) -lt 100 ]]
+    else
+      [[ $(( stagedTxIdsCount )) -gt 0 ]]
+    fi
   readiness_probe.sh: |-
     #!/usr/bin/env bash
     set -ex

--- a/9c-main/miner-2.yaml
+++ b/9c-main/miner-2.yaml
@@ -72,13 +72,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/bash
-            - -c
-            - "set -e\nlast_block=\"$(\n  curl \\\n    -H 'Content-Type: application/json'\
-              \ \\\n    --data '{\"query\":\"query{chainQuery{blockQuery{blocks(desc:true,limit:1){timestamp}}}}\"\
-              }' \\\n    http://localhost:80/graphql \\\n  | jq -r '.data.chainQuery.blockQuery.blocks[0].timestamp'\n\
-              )\"\nlast_timestamp=\"$(date +%s -u --date=\"$last_block\")\"\nnow=\"\
-              $(date +%s -u)\"\n[[ $(( now - last_timestamp )) -lt 100 ]]\n"
+            - /bin/liveness_probe_miner.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30
@@ -93,6 +87,10 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: main-miner-2-data
+        - mountPath: /bin/liveness_probe_miner.sh
+          name: probe-script
+          readOnly: true
+          subPath: liveness_probe_miner.sh
       dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: acr-regcred
@@ -103,6 +101,11 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 448
+          name: probe-script
+        name: probe-script
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/9c-main/snapshot-partition.yaml
+++ b/9c-main/snapshot-partition.yaml
@@ -75,7 +75,7 @@ spec:
                   name: version-config
                   key: APP_PROTOCOL_VERSION
           nodeSelector:
-            alpha.eksctl.io/nodegroup-name: 9c-main-4xl
+            alpha.eksctl.io/nodegroup-name: 9c-main-2xl
             beta.kubernetes.io/os: linux
           restartPolicy: Never
           volumes:


### PR DESCRIPTION
The miner liveness probe is now updated to check its `stageTxIdCount`(0 indirectly indicates that it's cut off from the network) and its `tip block timestamp`.