### PR TITLE
[9c-internal] change gp2 to gp3

### DIFF
--- a/9c-internal/data-provider-db.yaml
+++ b/9c-internal/data-provider-db.yaml
@@ -39,6 +39,6 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 100Gi
-        storageClassName: gp2-extensible-us-east-2c
+            storage: 10Gi
+        storageClassName: gp3
         volumeMode: Filesystem

--- a/9c-internal/onboarding-db.yaml
+++ b/9c-internal/onboarding-db.yaml
@@ -42,5 +42,5 @@ spec:
         resources:
           requests:
             storage: 1Gi
-        storageClassName: gp2-extensible
+        storageClassName: gp3
         volumeMode: Filesystem


### PR DESCRIPTION
Changes `internal-data-provider-db` and `internal-onboarding-db`'s storageclass to `gp3` which has a default `Delete` policy.