### PR TITLE
[9c-onboarding] Update instance types

### DIFF
--- a/9c-onboarding/sts-headless-query.yaml
+++ b/9c-onboarding/sts-headless-query.yaml
@@ -46,7 +46,7 @@ spec:
         - --tx-life-time=60
         command:
         - dotnet
-        image: kustomization-onboarding-headless
+        image: planetariumhq/ninechronicles-headless:v100351-1
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_PROTOCOL_VERSION_KEY
@@ -103,7 +103,7 @@ spec:
           subPath: probe_tip.sh
       dnsPolicy: ClusterFirst
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-onboarding-m6g-2xl
+        alpha.eksctl.io/nodegroup-name: 9c-onboarding-r6g-xl
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-onboarding/sts-headless-query.yaml
+++ b/9c-onboarding/sts-headless-query.yaml
@@ -46,7 +46,7 @@ spec:
         - --tx-life-time=60
         command:
         - dotnet
-        image: planetariumhq/ninechronicles-headless:v100351-1
+        image: kustomization-onboarding-headless
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_PROTOCOL_VERSION_KEY

--- a/9c-onboarding/sts-headless-transfer.yaml
+++ b/9c-onboarding/sts-headless-transfer.yaml
@@ -46,7 +46,7 @@ spec:
         - --tx-life-time=60
         command:
         - dotnet
-        image: planetariumhq/ninechronicles-headless:v100351-1
+        image: kustomization-onboarding-headless
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_PROTOCOL_VERSION_KEY

--- a/9c-onboarding/sts-headless-transfer.yaml
+++ b/9c-onboarding/sts-headless-transfer.yaml
@@ -46,7 +46,7 @@ spec:
         - --tx-life-time=60
         command:
         - dotnet
-        image: kustomization-onboarding-headless
+        image: planetariumhq/ninechronicles-headless:v100351-1
         imagePullPolicy: IfNotPresent
         env:
         - name: APP_PROTOCOL_VERSION_KEY
@@ -107,7 +107,7 @@ spec:
           subPath: probe_tip_diff.sh
       dnsPolicy: ClusterFirst
       nodeSelector:
-        alpha.eksctl.io/nodegroup-name: 9c-onboarding-m5-xl
+        alpha.eksctl.io/nodegroup-name: 9c-onboarding
         beta.kubernetes.io/os: linux
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-onboarding/world-boss-service.yaml
+++ b/9c-onboarding/world-boss-service.yaml
@@ -69,9 +69,10 @@ spec:
           name: world-boss-service
           ports:
             - containerPort: 5000
+      nodeSelector:
+        alpha.eksctl.io/nodegroup-name: 9c-onboarding
+        beta.kubernetes.io/os: linux
       restartPolicy: Always
-      imagePullSecrets:
-        - name: regcred
       serviceAccount: aws-iam-role
       serviceAccountName: aws-iam-role
   updateStrategy:

--- a/9c-onboarding/world-boss-worker.yaml
+++ b/9c-onboarding/world-boss-worker.yaml
@@ -69,9 +69,10 @@ spec:
           name: world-boss-worker
           ports:
             - containerPort: 5000
+      nodeSelector:
+        alpha.eksctl.io/nodegroup-name: 9c-onboarding
+        beta.kubernetes.io/os: linux
       restartPolicy: Always
-      imagePullSecrets:
-        - name: regcred
       serviceAccount: aws-iam-role
       serviceAccountName: aws-iam-role
   updateStrategy:


### PR DESCRIPTION
* sts-headless-query: `m6g.2xl` to `r6g.xl`
* sts-headless-query, world-boss-service, world-boss-worker: `m5.xl` to `m5.l`