### PR TITLE
Fix internal snapshot script

### DIFF
--- a/9c-internal/configmap-snapshot-script.yaml
+++ b/9c-internal/configmap-snapshot-script.yaml
@@ -231,7 +231,7 @@ data:
         exit 1
       fi
 
-      if timeout 1800 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync finished;"; then
+      if timeout 1800 tail -f "$HEADLESS_LOG" | grep -m1 "preloading is no longer needed"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload." $1
@@ -246,7 +246,7 @@ data:
       if ! kill -0 "$PID"; then
         echo "$PID doesn't exist. Failed to kill headless"
       else
-        kill -KILL "$PID"
+        kill "$PID"
         waitpid "$PID" || true
         chmod 777 -R "$STORE_PATH"
       fi


### PR DESCRIPTION
currently, our snapshot script starts headless and checks if preload is done by `CompleteBlocksAsync finished` message.
but if the preloading occurs multiple times, it kills headless during second preloading.
Also, `kill -KILL` signal doesn't kill headless gracefully.

now it is the test for internal only. if it goes well, it will be added to mainnet snapshot scripts