### PR TITLE
fix parsing error

### DIFF
--- a/9c-internal/deploy-internal.sh
+++ b/9c-internal/deploy-internal.sh
@@ -123,7 +123,7 @@ echo "Do you want to reset the cluster with a new snapshot(y/n)?"
 read response
 
 checkout_internal_cluster || true
-slack_webhook_url=$(kubectl get secrets/slack  --template='{{.data.slack-webhook-url | base64decode}}')
+slack_webhook_url=$(kubectl get secrets/slack  --template='{{.data.slack_webhook_url | base64decode}}')
 echo $slack_webhook_url
 
 clear_cluster $slack_webhook_url || true


### PR DESCRIPTION
`kubectl get secrets/slack  --template='{{.data.slack_webhook_url | base64decode}}'`
This command can't take `-` for some reason so I changed the original `slack-webhook-url` key name to `slack_webhook_url`.