### PR TITLE
[9c-main] update config

### DIFF
--- a/9c-main/configmap-partition.yaml
+++ b/9c-main/configmap-partition.yaml
@@ -50,7 +50,6 @@ data:
       chmod 777 -R "$STORE_PATH"
 
       "$HEADLESS" \
-          --workers=50 \
           --no-miner \
           --genesis-block-path="$GENESIS_BLOCK_PATH" \
           --store-type=rocksdb \

--- a/9c-main/remote-headless-1.yaml
+++ b/9c-main/remote-headless-1.yaml
@@ -82,7 +82,7 @@ spec:
             configMapKeyRef:
               name: version-config
               key: APP_PROTOCOL_VERSION
-        image: planetariumhq/ninechronicles-headless:v100360-1
+        image: planetariumhq/ninechronicles-headless:git-5f27ba311d623026cc96d048a34a88aabf5e0ca3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/9c-main/remote-headless-2.yaml
+++ b/9c-main/remote-headless-2.yaml
@@ -82,7 +82,7 @@ spec:
             configMapKeyRef:
               name: version-config
               key: APP_PROTOCOL_VERSION
-        image: planetariumhq/ninechronicles-headless:v100360-1
+        image: planetariumhq/ninechronicles-headless:git-5f27ba311d623026cc96d048a34a88aabf5e0ca3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/9c-main/remote-headless-3.yaml
+++ b/9c-main/remote-headless-3.yaml
@@ -82,7 +82,7 @@ spec:
             configMapKeyRef:
               name: version-config
               key: APP_PROTOCOL_VERSION
-        image: planetariumhq/ninechronicles-headless:v100360-1
+        image: planetariumhq/ninechronicles-headless:git-5f27ba311d623026cc96d048a34a88aabf5e0ca3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/9c-main/remote-headless-31.yaml
+++ b/9c-main/remote-headless-31.yaml
@@ -60,7 +60,7 @@ spec:
         - --tx-life-time=60
         command:
         - dotnet
-        image: planetariumhq/ninechronicles-headless:v100360-1
+        image: planetariumhq/ninechronicles-headless:git-5f27ba311d623026cc96d048a34a88aabf5e0ca3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/9c-main/remote-headless-4.yaml
+++ b/9c-main/remote-headless-4.yaml
@@ -82,7 +82,7 @@ spec:
             configMapKeyRef:
               name: version-config
               key: APP_PROTOCOL_VERSION
-        image: planetariumhq/ninechronicles-headless:v100360-1
+        image: planetariumhq/ninechronicles-headless:git-5f27ba311d623026cc96d048a34a88aabf5e0ca3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/9c-main/remote-headless-5.yaml
+++ b/9c-main/remote-headless-5.yaml
@@ -82,7 +82,7 @@ spec:
             configMapKeyRef:
               name: version-config
               key: APP_PROTOCOL_VERSION
-        image: planetariumhq/ninechronicles-headless:v100360-1
+        image: planetariumhq/ninechronicles-headless:git-5f27ba311d623026cc96d048a34a88aabf5e0ca3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
* Change RPC image to rate-limit version (We should continue using this for the hotfix).
* Remove --worker option in snapshot-partition script.