### PR TITLE
remove dp deployment due to maintenance

### DIFF
--- a/9c-main/deploy-main.sh
+++ b/9c-main/deploy-main.sh
@@ -28,8 +28,6 @@ clear_cluster() {
     main-full-state \
     main-miner-3 \
     explorer \
-    main-data-provider \
-    main-data-provider-db \
     remote-headless-1 \
     remote-headless-2 \
     remote-headless-3 \
@@ -67,8 +65,6 @@ deploy_cluster() {
     -f $BASEDIR/full-state.yaml \
     -f $BASEDIR/miner-3.yaml \
     -f $BASEDIR/explorer.yaml \
-    -f $BASEDIR/data-provider.yaml \
-    -f $BASEDIR/data-provider-db.yaml \
     -f $BASEDIR/remote-headless-1.yaml \
     -f $BASEDIR/remote-headless-2.yaml \
     -f $BASEDIR/remote-headless-3.yaml \


### PR DESCRIPTION
Do not delete dp services when deploying `v100361-2` hotfix because they are currently under maintenance.