### PR TITLE
fix checking complete log

### DIFF
--- a/9c-main/configmap-full.yaml
+++ b/9c-main/configmap-full.yaml
@@ -81,7 +81,7 @@ data:
         exit 1
       fi
 
-      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync finished;"; then
+      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload."

--- a/9c-main/configmap-partition-reset.yaml
+++ b/9c-main/configmap-partition-reset.yaml
@@ -81,7 +81,7 @@ data:
         exit 1
       fi
 
-      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync finished;"; then
+      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload."

--- a/9c-main/configmap-partition.yaml
+++ b/9c-main/configmap-partition.yaml
@@ -81,7 +81,7 @@ data:
         exit 1
       fi
 
-      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync finished;"; then
+      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload."


### PR DESCRIPTION
https://github.com/planetarium/libplanet/commit/863fe31f6d363ad4b97abbe6a4fad390d7ebec2b#diff-215bb45126357b0974dea14401f0213b497011890a129ae3a7df3e3468ea4911R328

CompleteBlocksAsync log updated so that snapshot preload cannot check it finished.