### PR TITLE
Update snapshot config

### DIFF
--- a/9c-main/configmap-full.yaml
+++ b/9c-main/configmap-full.yaml
@@ -81,7 +81,7 @@ data:
         exit 1
       fi
 
-      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
+      if timeout 144000 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload."

--- a/9c-main/configmap-partition-reset.yaml
+++ b/9c-main/configmap-partition-reset.yaml
@@ -81,7 +81,7 @@ data:
         exit 1
       fi
 
-      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
+      if timeout 144000 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload."

--- a/9c-main/configmap-partition.yaml
+++ b/9c-main/configmap-partition.yaml
@@ -81,7 +81,7 @@ data:
         exit 1
       fi
 
-      if timeout 14400 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
+      if timeout 144000 tail -f "$HEADLESS_LOG" | grep -m1 "CompleteBlocksAsync() finished;"; then
         sleep 30
       else
         senderr "grep failed. Failed to preload."

--- a/9c-main/snapshot-full.yaml
+++ b/9c-main/snapshot-full.yaml
@@ -19,6 +19,10 @@ spec:
             - /bin/upload_snapshot.sh
             image: planetariumhq/ninechronicles-snapshot:git-9af8f34a244a3c1ce1bcd16d12cf61807319b8d7
             name: upload-snapshot
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/upload_snapshot.sh
               name: snapshot-script-full
@@ -53,6 +57,10 @@ spec:
             - /bin/preload_headless.sh
             image: planetariumhq/ninechronicles-headless:v100361-3
             name: preload-headless
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/preload_headless.sh
               name: snapshot-script-full

--- a/9c-main/snapshot-partition-reset.yaml
+++ b/9c-main/snapshot-partition-reset.yaml
@@ -20,6 +20,10 @@ spec:
             - /bin/replace_snapshot.sh
             image: nginx
             name: replace-snapshot
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/replace_snapshot.sh
               name: snapshot-script-partition-reset
@@ -51,6 +55,10 @@ spec:
             - /bin/upload_snapshot.sh
             image: planetariumhq/ninechronicles-snapshot:git-9af8f34a244a3c1ce1bcd16d12cf61807319b8d7
             name: upload-snapshot1
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/upload_snapshot.sh
               name: snapshot-script-partition-reset
@@ -86,6 +94,10 @@ spec:
             - /bin/upload_snapshot.sh
             image: planetariumhq/ninechronicles-snapshot:git-9af8f34a244a3c1ce1bcd16d12cf61807319b8d7
             name: upload-snapshot2
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/upload_snapshot.sh
               name: snapshot-script-partition-reset

--- a/9c-main/snapshot-partition.yaml
+++ b/9c-main/snapshot-partition.yaml
@@ -19,6 +19,10 @@ spec:
             - /bin/upload_snapshot.sh
             image: planetariumhq/ninechronicles-snapshot:git-9af8f34a244a3c1ce1bcd16d12cf61807319b8d7
             name: upload-snapshot
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/upload_snapshot.sh
               name: snapshot-script-partition
@@ -53,6 +57,10 @@ spec:
             - /bin/preload_headless.sh
             image: planetariumhq/ninechronicles-headless:v100361-3
             name: preload-headless
+            resources:
+              requests:
+                cpu: 1300m
+                memory: 10Gi
             volumeMounts:
             - mountPath: /bin/preload_headless.sh
               name: snapshot-script-partition


### PR DESCRIPTION
* Request resources so that each cronjob can fully use a single instance.
* Increase timeout because each cronjob schedule is increase to a 12-hour interval.