### PR TITLE
temporarily halt rpc99 deployment in v200000

### DIFF
--- a/9c-main/deploy-main.sh
+++ b/9c-main/deploy-main.sh
@@ -44,8 +44,7 @@ deploy_cluster() {
   # Start remaining services
   echo "Start remaining services"
   kubectl apply  \
-    -f $BASEDIR/remote-headless-31.yaml \
-    -f $BASEDIR/remote-headless-99.yaml
+    -f $BASEDIR/remote-headless-31.yaml
 }
 
 echo "Checkout 9c-main cluster."


### PR DESCRIPTION
Preserve RPC99's pvc in case we need to roll back.